### PR TITLE
Feature/psilord/transform api extensions

### DIFF
--- a/core/components/transform.lisp
+++ b/core/components/transform.lisp
@@ -201,14 +201,20 @@
     (when instant-p
       (m:copy-into previous current))))
 
-;; TODO: Make inverses of these three functions.
-;; TODO: Try and get rid of any produced garbage in these three functions too.
+;; TODO: Try and get rid of any produced garbage in the functions below.
 
 (defun transform-point (transform point-vec)
   "Transform the vector in POINT-VEC, assumed to be in the local space of the
 TRANSFORM, to world space and returns the new vector. The new vector is affected
 by scale, rotation, and translation. A newly allocated M:VEC3 is returned."
   (m:vec3 (m:* (model transform) (m:vec4 point-vec 1))))
+
+(defun inverse-transform-point (transform point-vec)
+  "Transform the vector in POINT-VEC, assumed to be in the world space, to the
+local space of the TRANSFORM and returns the new vector. The new vector is
+affected by scale, rotation, and translation. A newly allocated M:VEC3 is
+returned."
+  (m:vec3 (m:* (m:invert (model transform)) (m:vec4 point-vec 1))))
 
 (defun transform-vector (transform vector-vec)
   "Transform the vector in VECTOR-VEC, assumed to be in the local space of the
@@ -220,6 +226,19 @@ rotation, but not by translation. A newly allocated M:VEC3 is returned."
                        zero-translation-model)
 
     (m:vec3 (m:* zero-translation-model (m:vec4 vector-vec 1)))))
+
+(defun inverse-transform-vector (transform vector-vec)
+  "Transform the vector in VECTOR-VEC, assumed to be in the world space,
+to the local space of the TRANSFORM and return it. The new vector is affected by
+scale and rotation, but not by translation. A newly allocated M:VEC3 is
+returned."
+  (let ((zero-translation-model (m:copy (model transform))))
+
+    (m:set-translation zero-translation-model (m:vec3)
+                       zero-translation-model)
+
+    (m:vec3 (m:* (m:invert zero-translation-model) (m:vec4 vector-vec 1)))))
+
 
 (defun transform-direction (transform direction-vec)
   "Transform the vector in DIRECTION-VEC, assumed to be in the local space of
@@ -237,3 +256,51 @@ returned."
 
     (m:vec3 (m:* zero-translation-identity-scale-model
                  (m:vec4 direction-vec 1)))))
+
+(defun inverse-transform-direction (transform direction-vec)
+  "Transform the vector in DIRECTION-VEC, assumed to be in world space,
+to the local space of the TRANSFORM and return it. The new vector is affected
+only by rotation, and not by translation or scale. A newly allocated M:VEC3 is
+returned."
+  (let ((zero-translation-identity-scale-model (m:copy (model transform))))
+
+    (m:set-translation zero-translation-identity-scale-model (m:vec3)
+                       zero-translation-identity-scale-model)
+
+    ;; TODO: Just need to normalize the rotation portion, not also
+    ;; make it ortho, but there is no math function for it. We need to
+    ;; write one.
+    (m::orthonormalize zero-translation-identity-scale-model
+                       zero-translation-identity-scale-model)
+
+    (m:vec3 (m:* (m:invert zero-translation-identity-scale-model)
+                 (m:vec4 direction-vec 1)))))
+
+;; NOTE:
+;; We define these axes as the directions for an object in FL:
+;;
+;; +z back, -z forward, +y up, -y down, +x right, -x left
+
+(defun transform-forward (transform)
+  "Return the forward vector (-Z axis) in world space for this TRANSFORM."
+  (m:negate (m:vec3 (m:get-column (model transform) 2))))
+
+(defun transform-backward (transform)
+  "Return the backward vector (+Z axis) in world space for this TRANSFORM."
+  (m:vec3 (m:get-column (model transform) 2)))
+
+(defun transform-up (transform)
+  "Return the up vector (+Y axis) in world space for this TRANSFORM."
+  (m:vec3 (m:get-column (model transform) 1)))
+
+(defun transform-down (transform)
+  "Return the down vector (-Y axis) in world space for this TRANSFORM."
+  (m:negate (m:vec3 (m:get-column (model transform) 1))))
+
+(defun transform-right (transform)
+  "Return the right vector (+X axis) in world space for this TRANSFORM."
+  (m:vec3 (m:get-column (model transform) 0)))
+
+(defun transform-left (transform)
+  "Return the left vector (+X axis) in world space for this TRANSFORM."
+  (m:negate (m:vec3 (m:get-column (model transform) 0))))

--- a/core/components/transform.lisp
+++ b/core/components/transform.lisp
@@ -276,7 +276,9 @@ returned."
     (m:vec3 (m:* (m:invert zero-translation-identity-scale-model)
                  (m:vec4 direction-vec 1)))))
 
-;; NOTE:
+;; NOTE: These functions return the vectors that represent
+;; forward, backward, up, down, right, and left in _world space_.
+;;
 ;; We define these axes as the directions for an object in FL:
 ;;
 ;; +z back, -z forward, +y up, -y down, +x right, -x left

--- a/core/packages/components.lisp
+++ b/core/packages/components.lisp
@@ -62,5 +62,14 @@
    #:rotate
    #:scale
    #:transform-point
+   #:inverse-transform-point
    #:transform-vector
-   #:transform-direction))
+   #:inverse-transform-vector
+   #:transform-direction
+   #:inverse-transform-direction
+   #:transform-forward
+   #:transform-backward
+   #:transform-up
+   #:transform-down
+   #:transform-right
+   #:transform-left))

--- a/examples/example-collision.lisp
+++ b/examples/example-collision.lisp
@@ -116,40 +116,71 @@
   (let* ((actor (fl:actor self))
          (actor-transform
            (fl:actor-component-by-type actor 'fl.comp:transform))
-         (test-0/object-space-point-0 (m:vec3 1 1 1))
-         (test-0/world-space-point-0 (m:vec3 2 2 2))
-         (test-0/local->world
+         (object-space-point (m:vec3 1 0 0))
+         (world-space-point (m:vec3 1 3 1))
+         (local->world
            (fl.comp:transform-point actor-transform
-                                    test-0/object-space-point-0))
-         (test-0/world->local
+                                    object-space-point))
+         (world->local
            (fl.comp:inverse-transform-point actor-transform
-                                            test-0/world-space-point-0)))
+                                            world-space-point)))
 
     ;; See if transform-point and inverse-transform-point work.
-    (let ((test-0/result-0
-            (m:~ test-0/local->world test-0/world-space-point-0))
-          (test-0/result-1
-            (m:~ test-0/world->local test-0/object-space-point-0)))
+    (let ((result-0
+            (m:~ local->world world-space-point))
+          (result-1
+            (m:~ world->local object-space-point)))
 
-      (unless (and test-0/result-0 test-0/result-1)
-        (unless test-0/result-0
-          (v:debug
+      (unless (and result-0 result-1)
+        (unless result-0
+          (v:error
            :fl.example
-           "FAILED: (m:~~ test-0/local->world:~A test-0/world-space-point0: ~A) -> ~A"
-           test-0/local->world test-0/world-space-point-0 test-0/result-0))
+           "FAILED: (m:~~ local->world:~A world-space-point: ~A) -> ~A"
+           local->world world-space-point result-0))
 
-        (unless test-0/result-1
-          (v:debug
+        (unless result-1
+          (v:error
            :fl.example
-           "FAILED: (m:~~ test-0/world->local:~A test-0/object-space-point-0: ~A) -> ~A"
-           test-0/world->local test-0/object-space-point-0 test-0/result-1))
+           "FAILED: (m:~~ world->local:~A object-space-point: ~A) -> ~A"
+           world->local object-space-point result-1))
 
-        (error "TRANSFORM-POINT Failed test-0")))))
+        (error "TRANSFORM-POINT API Failed!")))))
 
 (defun test-transform-vector-api (self)
-  (declare (ignore self))
-  ;; TODO implement test-transform-vector-api
-  nil)
+  "Test if the TRANSFORM-VECTOR and INVERSE-TRANSFORM-VECTOR work."
+  (let* ((actor (fl:actor self))
+         (actor-transform
+           (fl:actor-component-by-type actor 'fl.comp:transform))
+         (object-space-vector (m:vec3 2 2 0))
+         (world-space-vector (m:vec3 -4 4 0))
+         (local->world
+           (fl.comp:transform-vector actor-transform
+                                     object-space-vector))
+         (world->local
+           (fl.comp:inverse-transform-vector actor-transform
+                                             world-space-vector)))
+
+    ;; See if transform-point and inverse-transform-point work.
+    (let ((result-0
+            (m:~ local->world world-space-vector))
+          (result-1
+            (m:~ world->local object-space-vector)))
+
+      (unless (and result-0 result-1)
+        (unless result-0
+          (v:error
+           :fl.example
+           "FAILED: (m:~~ local->world:~A world-space-vector: ~A) -> ~A"
+           local->world world-space-vector result-0))
+
+        (unless result-1
+          (v:error
+           :fl.example
+           "FAILED: (m:~~ world->local:~A object-space-vector: ~A) -> ~A"
+           world->local object-space-vector result-1))
+
+        (error "TRANSFORM-VECTOR API Failed!")))))
+
 
 (defun test-transform-direction-api (self)
   (declare (ignore self))
@@ -195,7 +226,11 @@ world space for a particular transform."
     (fl.comp:transform :translate (m:vec3 0 1 0))
     ("back"
      (fl.comp:transform :translate (m:vec3 0 0 1))
-     ("mark" ;; Sitting at 1,1,1 wrt the universe.
+     ("mark"
+      ;; Origin sitting at 1,1,1 wrt the universe, but +90deg rotation around
+      ;; "mark" Z axis.
+      (fl.comp:transform :rotate (m:vec3 0 0 (/ pi 2))
+                         :scale (m:vec3 2 2 2))
       (debug-transform :test-type :test-transform-api)
       (fl.comp:mesh :location '((:core :mesh) "plane.glb"))
       (fl.comp:render :material '2d-wood))))))

--- a/examples/example-collision.lisp
+++ b/examples/example-collision.lisp
@@ -183,9 +183,40 @@
 
 
 (defun test-transform-direction-api (self)
-  (declare (ignore self))
-  ;; TODO implement test-transform-vector-api
-  nil)
+  (let* ((actor (fl:actor self))
+         (actor-transform
+           (fl:actor-component-by-type actor 'fl.comp:transform))
+         ;; NOTE: these must be normalized for the test. I specified it this way
+         ;; so it would be easier to see in your mind's eye.
+         (object-space-direction (m:normalize (m:vec3 1 1 0)))
+         (world-space-direction (m:normalize (m:vec3 -1 1 0)))
+         (local->world
+           (fl.comp:transform-direction actor-transform
+                                        object-space-direction))
+         (world->local
+           (fl.comp:inverse-transform-direction actor-transform
+                                                world-space-direction)))
+
+    ;; See if transform-point and inverse-transform-point work.
+    (let ((result-0
+            (m:~ local->world world-space-direction))
+          (result-1
+            (m:~ world->local object-space-direction)))
+
+      (unless (and result-0 result-1)
+        (unless result-0
+          (v:error
+           :fl.example
+           "FAILED: (m:~~ local->world:~A world-space-direction: ~A) -> ~A"
+           local->world world-space-direction result-0))
+
+        (unless result-1
+          (v:error
+           :fl.example
+           "FAILED: (m:~~ world->local:~A object-space-direction: ~A) -> ~A"
+           world->local object-space-direction result-1))
+
+        (error "TRANSFORM-DIRECTION API Failed!")))))
 
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/examples/example-collision.lisp
+++ b/examples/example-collision.lisp
@@ -29,42 +29,15 @@
   (when (<= (time-to-destroy self) 0)
     (fl:destroy (fl:actor self))))
 
-(fl:define-prefab "collision-smoke-test" (:library examples)
-  (("camera" :copy "/cameras/perspective")
-   (fl.comp:camera (:policy :new-args) :zoom 6))
-  ("rot-0-center"
-   (fl.comp:transform :translate (m:vec3 -2 0 0)
-                      :rotate/inc (m:vec3 0 0 pi))
-   ("plane-0"
-    (fl.comp:transform :translate (m:vec3 -2 0 0))
-    (fl.comp:mesh :location '((:core :mesh) "plane.glb"))
-    (fl.comp:collider/sphere
-     :display-id "Player"
-     :on-layer :player
-     :center (m:vec3)
-     :radius 1)
-    (fl.comp:render :material '2d-wood)))
-  ("rot-1-center"
-   (fl.comp:transform :translate (m:vec3 2 0 0)
-                      :rotate/inc (m:vec3 0 0 (- pi)))
-   ("plane-1"
-    (fl.comp:transform :translate (m:vec3 2 0 0))
-    (fl.comp:mesh :location '((:core :mesh) "plane.glb"))
-    (fl.comp:collider/sphere
-     :display-id "Enemy"
-     :on-layer :enemy
-     :center (m:vec3)
-     :radius 1)
-    (fl.comp:render :material '2d-wood))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Testing getting the directions from a transform
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(fl:define-component debug-transform ()
+(fl:define-component unit-test-transform-api ()
   ((test-type :default nil) ;; You must specify this
    (test-performed :default (au:dict #'eq))))
 
-(defmethod fl:on-component-physics-update ((self debug-transform))
+(defmethod fl:on-component-physics-update ((self unit-test-transform-api))
   (ecase (test-type self)
     (:test-direction-vectors
      (test-axis-directions self))
@@ -223,6 +196,34 @@
 ;; The test prefabs.
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(fl:define-prefab "collision-smoke-test" (:library examples)
+  (("camera" :copy "/cameras/perspective")
+   (fl.comp:camera (:policy :new-args) :zoom 6))
+  ("rot-0-center"
+   (fl.comp:transform :translate (m:vec3 -2 0 0)
+                      :rotate/inc (m:vec3 0 0 pi))
+   ("plane-0"
+    (fl.comp:transform :translate (m:vec3 -2 0 0))
+    (fl.comp:mesh :location '((:core :mesh) "plane.glb"))
+    (fl.comp:collider/sphere
+     :display-id "Player"
+     :on-layer :player
+     :center (m:vec3)
+     :radius 1)
+    (fl.comp:render :material '2d-wood)))
+  ("rot-1-center"
+   (fl.comp:transform :translate (m:vec3 2 0 0)
+                      :rotate/inc (m:vec3 0 0 (- pi)))
+   ("plane-1"
+    (fl.comp:transform :translate (m:vec3 2 0 0))
+    (fl.comp:mesh :location '((:core :mesh) "plane.glb"))
+    (fl.comp:collider/sphere
+     :display-id "Enemy"
+     :on-layer :enemy
+     :center (m:vec3)
+     :radius 1)
+    (fl.comp:render :material '2d-wood))))
+
 (fl:define-prefab "collision-transform-test-0" (:library examples)
   "This test just prints out the directions of the actor transform. Since
 the actor is at universe 0,0,0 and has no rotations, we should see the
@@ -238,9 +239,9 @@ unit world vector representations of the axis directions as:
    (fl.comp:camera (:policy :new-args) :zoom 7))
 
   ("thingy"
-   ;; NOTE: The 5 0 0 is specific to the debug-transform tests.
+   ;; NOTE: The 5 0 0 is specific to the unit-test-transform-api tests.
    (fl.comp:transform :translate (m:vec3 5 0 0))
-   (debug-transform :test-type :test-direction-vectors)
+   (unit-test-transform-api :test-type :test-direction-vectors)
    (fl.comp:mesh :location '((:core :mesh) "plane.glb"))
    (fl.comp:render :material '2d-wood)))
 
@@ -262,7 +263,7 @@ world space for a particular transform."
       ;; "mark" Z axis.
       (fl.comp:transform :rotate (m:vec3 0 0 (/ pi 2))
                          :scale (m:vec3 2 2 2))
-      (debug-transform :test-type :test-transform-api)
+      (unit-test-transform-api :test-type :test-transform-api)
       (fl.comp:mesh :location '((:core :mesh) "plane.glb"))
       (fl.comp:render :material '2d-wood))))))
 


### PR DESCRIPTION
This branch adds additional transform component API to move points, vectors, and directions vectors back and forth between object space and world space. It also adds a new API for the transform component that allows users to get the forward, backward, up, down, right, and left vectors in world space for any transform. I extended the example-collisions demo to include some unit tests for this new API.

Following opengl, we define these vectors as:

+z back, -z forward, +y up, -y down, +x right, -x left

Notice -z is forward, this is because it is the way you look "out" of a camera. So to move
in your forward direction, you'd be moving down the -z axis.